### PR TITLE
Improve matching of elements in headers

### DIFF
--- a/tei_make_corpus/header_handler.py
+++ b/tei_make_corpus/header_handler.py
@@ -38,7 +38,7 @@ class TeiHeaderHandlerImpl:
         as each @key='value' pair is present on both elements.
 
         """
-        for element in self._cheader.iterdescendants():
+        for element in self._cheader.findall(".//*"):
             if etree.QName(element.tag).localname in self.tags_no_leftover_sibling:
                 continue
             matching = self._element_equivalent_in_individual_header(element, iheader)

--- a/tei_make_corpus/header_handler.py
+++ b/tei_make_corpus/header_handler.py
@@ -1,5 +1,5 @@
 import re
-from typing import Optional, Protocol
+from typing import List, Protocol
 
 from lxml import etree
 
@@ -43,29 +43,30 @@ class TeiHeaderHandlerImpl:
             if etree.QName(element.tag).localname in self.tags_no_leftover_sibling:
                 continue
             matching = self._element_equivalent_in_individual_header(element, iheader)
-            if matching is not None:
-                if elements_equal(element, matching, ignore_ns=True):
-                    matching.getparent().remove(matching)
+            for struct_match in matching:
+                if elements_equal(element, struct_match, ignore_ns=True):
+                    struct_match.getparent().remove(struct_match)
         for element in self._cheader.iterdescendants(self.tags_no_leftover_sibling):
             matching = self._element_equivalent_in_individual_header(element, iheader)
-            if matching is not None:
-                if elements_equal(element, matching, ignore_ns=True):
-                    if matching.getnext() is None:
-                        matching.getparent().replace(matching, etree.Element("p"))
+            for struct_match in matching:
+                if elements_equal(element, struct_match, ignore_ns=True):
+                    if struct_match.getnext() is None:
+                        struct_match.getparent().replace(
+                            struct_match, etree.Element("p")
+                        )
 
     def _construct_common_header(self, header_file: str) -> etree._Element:
         return etree.parse(header_file).getroot()
 
     def _element_equivalent_in_individual_header(
         self, element: etree._Element, iheader: etree._Element
-    ) -> Optional[etree._Element]:
+    ) -> List[etree._Element]:
         cheader_tree = self._cheader.getroottree()
         elem_xpath = cheader_tree.getelementpath(element)
-        matching = iheader.find(
+        return iheader.findall(
             self._adjust_xpath(elem_xpath),
             namespaces={None: "http://www.tei-c.org/ns/1.0"},
         )
-        return matching
 
     def _adjust_xpath(self, xpath: str) -> str:
         return f"./{self._clean_position_indices_from_path(xpath)}"

--- a/tei_make_corpus/header_handler.py
+++ b/tei_make_corpus/header_handler.py
@@ -39,7 +39,7 @@ class TeiHeaderHandlerImpl:
         as each @key='value' pair is present on both elements.
 
         """
-        for element in self._cheader.findall(".//*"):
+        for element in self._cheader.iterdescendants():
             if etree.QName(element.tag).localname in self.tags_no_leftover_sibling:
                 continue
             matching = self._element_equivalent_in_individual_header(element, iheader)

--- a/tei_make_corpus/header_handler.py
+++ b/tei_make_corpus/header_handler.py
@@ -1,3 +1,4 @@
+import re
 from typing import Optional, Protocol
 
 from lxml import etree
@@ -61,6 +62,14 @@ class TeiHeaderHandlerImpl:
         cheader_tree = self._cheader.getroottree()
         elem_xpath = cheader_tree.getelementpath(element)
         matching = iheader.find(
-            "./" + elem_xpath, namespaces={None: "http://www.tei-c.org/ns/1.0"}
+            self._adjust_xpath(elem_xpath),
+            namespaces={None: "http://www.tei-c.org/ns/1.0"},
         )
         return matching
+
+    def _adjust_xpath(self, xpath: str) -> str:
+        return f"./{self._clean_position_indices_from_path(xpath)}"
+
+    def _clean_position_indices_from_path(self, xpath: str) -> str:
+        pattern = r"\[\d+\]"
+        return re.sub(pattern, "", xpath)

--- a/tests/test_header_handler.py
+++ b/tests/test_header_handler.py
@@ -419,5 +419,52 @@ class TeiHeaderHandlerImplTest(unittest.TestCase):
         result = header_handler._clean_position_indices_from_path(path)
         self.assertEqual(result, "tag[@class1='value1']")
 
+    def test_all_matching_elements_from_individual_header_removed(self):
+        header_file = io.BytesIO(
+            b"""<teiHeader>
+                    <fileDesc>
+                        <titleStmt>
+                          <title>Corpus title</title>
+                        </titleStmt>
+                        <publicationStmt>
+                          <distributor>Publisher</distributor>
+                          <pubPlace>Place</pubPlace>
+                          <date>today</date>
+                        </publicationStmt>
+                        <notesStmt>
+                          <note>First note</note>
+                          <note>Second note</note>
+                        </notesStmt>
+                        <sourceDesc>
+                          <p/>
+                        </sourceDesc>
+                    </fileDesc>
+                </teiHeader>"""
+        )
+        header_handler = TeiHeaderHandlerImpl(header_file)
+        tei_doc = etree.XML(
+            """<TEI xmlns="http://www.tei-c.org/ns/1.0">
+            <teiHeader>
+            <fileDesc>
+              <titleStmt/>
+              <publicationStmt>
+                <distributor>Publisher</distributor>
+              </publicationStmt>
+              <notesStmt>
+                <note>First note</note>
+                <note>Second note</note>
+              </notesStmt>
+              <notesStmt>
+                <note>First note</note>
+                <note>Second note</note>
+              </notesStmt>
+            </fileDesc>
+          </teiHeader>
+          </TEI>"""
+        )
+        iheader = tei_doc.find(".//{*}teiHeader")
+        header_handler.declutter_individual_header(iheader)
+        self.assertEqual(tei_doc.findall(".//{*}notesStmt"), [])
+
     def assertXmlElementsEqual(self, element1, element2):
         self.assertTrue(elements_equal(element1, element2))

--- a/tests/test_header_handler.py
+++ b/tests/test_header_handler.py
@@ -335,5 +335,89 @@ class TeiHeaderHandlerImplTest(unittest.TestCase):
         header_handler.declutter_individual_header(iheader)
         self.assertEqual(tei_doc.findall(".//{*}address"), [])
 
+    def test_removal_of_elements_with_same_tag_under_one_parent(self):
+        header_file = io.BytesIO(
+            b"""<teiHeader>
+                    <fileDesc>
+                        <titleStmt>
+                            <title>Corpus title</title>
+                        </titleStmt>
+                        <publicationStmt>
+                          <publisher>Publisher</publisher>
+                          <address>
+                            <addrLine>street at city</addrLine>
+                            <addrLine>email@example.org</addrLine>
+                          </address>
+                          <pubPlace>Place</pubPlace>
+                          <date>today</date>
+                        </publicationStmt>
+                    </fileDesc>
+                </teiHeader>"""
+        )
+        header_handler = TeiHeaderHandlerImpl(header_file)
+        tei_doc = etree.XML(
+            """<TEI xmlns="http://www.tei-c.org/ns/1.0">
+                    <teiHeader>
+                    <fileDesc>
+                      <titleStmt/>
+                      <publicationStmt>
+                        <publisher>Publisher</publisher>
+                          <address>
+                            <addrLine>street at city</addrLine>
+                            <addrLine>other_email@example.org</addrLine>
+                          </address>
+                        <pubPlace>some place</pubPlace>
+                        <date>yesterday</date>
+                      </publicationStmt>
+                    </fileDesc>
+                  </teiHeader>
+                  </TEI>"""
+        )
+        iheader = tei_doc.find(".//{*}teiHeader")
+        header_handler.declutter_individual_header(iheader)
+        self.assertEqual(len(tei_doc.findall(".//{*}addrLine")), 1)
+
+    def test_position_indices_at_end_removed_from_xpath(self):
+        header_file = io.BytesIO(b"<header/>")
+        header_handler = TeiHeaderHandlerImpl(header_file)
+        path = "tag/subTag/other[1]"
+        self.assertEqual(
+            header_handler._clean_position_indices_from_path(path), "tag/subTag/other"
+        )
+
+    def test_path_constructed_correctly(self):
+        header_file = io.BytesIO(b"<header/>")
+        header_handler = TeiHeaderHandlerImpl(header_file)
+        path = "tag/subTag/other[1]"
+        self.assertEqual(header_handler._adjust_xpath(path), "./tag/subTag/other")
+
+    def test_position_indices_inside_path_removed(self):
+        header_file = io.BytesIO(b"<header/>")
+        header_handler = TeiHeaderHandlerImpl(header_file)
+        path = "tag/subTag/other[1]/someMore/else[19]"
+        result = header_handler._clean_position_indices_from_path(path)
+        self.assertEqual(result, "tag/subTag/other/someMore/else")
+
+    def test_tag_in_braces_not_removed_during_path_cleaning(self):
+        header_file = io.BytesIO(b"<header/>")
+        header_handler = TeiHeaderHandlerImpl(header_file)
+        path = "tag[tag2]"
+        result = header_handler._clean_position_indices_from_path(path)
+        self.assertEqual(result, "tag[tag2]")
+
+    def test_attributes_not_removed_from_path_during_cleaning(self):
+        header_file = io.BytesIO(b"<header/>")
+        header_handler = TeiHeaderHandlerImpl(header_file)
+        path = "tag[@class1]"
+        result = header_handler._clean_position_indices_from_path(path)
+        self.assertEqual(result, "tag[@class1]")
+
+    def test_attribute_with_value_not_removed_from_path_during_cleaning(self):
+        header_file = io.BytesIO(b"<header/>")
+        header_handler = TeiHeaderHandlerImpl(header_file)
+        path = "tag[@class1='value1']"
+        result = header_handler._clean_position_indices_from_path(path)
+        self.assertEqual(result, "tag[@class1='value1']")
+
     def assertXmlElementsEqual(self, element1, element2):
         self.assertTrue(elements_equal(element1, element2))

--- a/tests/test_header_handler.py
+++ b/tests/test_header_handler.py
@@ -287,5 +287,53 @@ class TeiHeaderHandlerImplTest(unittest.TestCase):
         header_handler.declutter_individual_header(iheader)
         self.assertEqual(tei_doc.findall(".//{*}encodingDesc"), [])
 
+    def test_elements_with_non_ascii_content_removed_if_equal(self):
+        header_file = io.BytesIO(
+            """<teiHeader>
+            <fileDesc>
+                <titleStmt>
+                    <title>Corpus title</title>
+                </titleStmt>
+                 <publicationStmt>
+                        <publisher>
+                        Corpus Publisher
+                        </publisher>
+                        <address>
+                          <addrLine>Äine Straße</addrLine>
+                        </address>
+                        <pubPlace>Berlin</pubPlace>
+                        <date>2022-10-11</date>
+                      </publicationStmt>
+                <sourceDesc>
+                  <p/>
+                </sourceDesc>
+            </fileDesc>
+        </teiHeader>""".encode(
+                "utf-8"
+            )
+        )
+        header_handler = TeiHeaderHandlerImpl(header_file)
+        tei_doc = etree.XML(
+            """<TEI xmlns="http://www.tei-c.org/ns/1.0">
+        <teiHeader>
+        <fileDesc>
+          <titleStmt/>
+      <publicationStmt>
+        <publisher>Publisher
+        </publisher>
+        <address>
+          <addrLine>Äine Straße</addrLine>
+        </address>
+        <pubPlace>City</pubPlace>
+        <date>2021-10-11</date>
+      </publicationStmt>
+        </fileDesc>
+      </teiHeader>
+      </TEI>"""
+        )
+        iheader = tei_doc.find(".//{*}teiHeader")
+        header_handler.declutter_individual_header(iheader)
+        self.assertEqual(tei_doc.findall(".//{*}address"), [])
+
     def assertXmlElementsEqual(self, element1, element2):
         self.assertTrue(elements_equal(element1, element2))

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -54,3 +54,17 @@ class IntegrationTest(unittest.TestCase):
         output_tree = etree.parse(pseudo)
         result = output_tree.getroot().getchildren()
         self.assertEqual(len(result), 5)
+
+    def test_element_with_non_ascii_text_removed_if_equal_in_common_header(self):
+        request = CliRequest(
+            header_file=os.path.join("tests", "testdata", "enc_corpus", "header.xml"),
+            corpus_dir=os.path.join("tests", "testdata", "enc_corpus"),
+        )
+        with contextlib.redirect_stdout(
+            io.TextIOWrapper(io.BytesIO(), sys.stdout.encoding)
+        ) as pseudo:
+            self.use_case.process(request)
+        pseudo.seek(0)
+        output_tree = etree.parse(pseudo)
+        result = output_tree.findall(".//{*}address")
+        self.assertEqual(len(result), 1)

--- a/tests/testdata/enc_corpus/file1.xml
+++ b/tests/testdata/enc_corpus/file1.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Title</title>
+        <author/>
+        <respStmt>
+          <resp n="1">some change</resp>
+          <name n="1">Person Name</name>
+        </respStmt>
+      </titleStmt>
+      <publicationStmt>
+        <publisher>Publisher</publisher>
+        <address>
+          <addrLine>Äine Straße 11, Ö</addrLine>
+        </address>
+        <pubPlace>The Earth</pubPlace>
+        <date>2022-07-20</date>
+        <authority>
+          <name/>
+        </authority>
+      </publicationStmt>
+    </fileDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <p>Actual text of the file</p>
+    </body>
+  </text>
+</TEI>

--- a/tests/testdata/enc_corpus/header.xml
+++ b/tests/testdata/enc_corpus/header.xml
@@ -1,0 +1,18 @@
+<teiHeader>
+    <fileDesc>
+        <titleStmt>
+            <title/>
+        </titleStmt>
+        <publicationStmt>
+            <publisher>Publisher 1</publisher>
+            <address>
+              <addrLine>Äine Straße 11, Ö</addrLine>
+            </address>
+            <pubPlace>Ö</pubPlace>
+            <date>2022-10-11</date>
+        </publicationStmt>
+        <sourceDesc>
+          <p/>
+        </sourceDesc>
+    </fileDesc>
+</teiHeader>


### PR DESCRIPTION
- clean xpath  of positions indices during header processing
- use xpath string to find all matching elements not only first match