### PR TITLE
Add option for insertion of document identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,20 @@ options:
                         inline table or, in multi-line format and used with
                         global table header, prefix the sub-table with 'tei-
                         make-corpus'.
+  --add-docid [{0,1,2,3}]
+                        Add an <idno/> element with @type='docId' attribute to
+                        teiHeader/fileDesc/publicationStmt to each TEI
+                        document in the teiCorpus containing a document
+                        identifier. The doc id is derived from the original
+                        filename. If used without value, it defaults to 0,
+                        i.e. the basename of the file is added as doc id.
+                        Otherwise, a predefined regex is used to search the
+                        filename and extract a capturing group that should be
+                        added as identifier. If the filename can't be matched,
+                        the basename is used instead and a warning is logged.
+                        Possible regular expressions are: {0: None, 1:
+                        '.*/\\w{2,3}_(\\w+)\\.xml$', 2: '.*/(\\w+)\\.', 3:
+                        '.*/\\w{2,3}_(.+)\\.xml$'}
 ```
 
 `tei-make-corpus` requires the path to a directory containing the TEI file and a file containing the information for the common header of the corpus.  
@@ -178,6 +192,22 @@ prefix_xmlid = true
 a = "b"
 a2 = "c"
 ```
+
+The option *--add-docid* can be used to add a document identifier to each TEI document. The doc id is derived from the original file path and as default the basename of the path is used. A set of predefined regular expressions is available to extract only part of the file path as document identifier, e.g.:
+
+```xml
+$ ls my_corpus
+PRE_Ahfb5ls.xml
+$ tei-make-corpus my_corpus -c header.xml --add-docid 1 | grep '<idno type="docId">'
+<idno type="docId">Ahfb5ls</idno>
+```
+
+The extracted doc id is added as text content of a `<idno/>` element with `@type='docId'`. This `<idno/>` element is inserted in `teiHeader/fileDesc/publicationStmt`:
+  - after the last `<idno/>` child, if present
+  - else: before `<availability/>`, if present
+  - else: as last child of `<publicationStmt/>`
+
+If the `<publicationStmt/>` is empty of contains only `<p/>` children, `<p/>` is used as tag for the new element and no `@type` attribute is added.
 
 
 ### Example usage

--- a/tei_make_corpus/cli/controller.py
+++ b/tei_make_corpus/cli/controller.py
@@ -9,7 +9,7 @@ if sys.version_info < (3, 11):
 else:
     import tomllib as toml
 
-from tei_make_corpus.cli.docid_pattern_map import PatternMap
+from tei_make_corpus.cli.docid_pattern_map import PATTERN_MAP
 from tei_make_corpus.cli.make_corpus_usecase import CliRequest, TeiMakeCorpusUseCase
 
 
@@ -20,7 +20,7 @@ class TeiMakeCorpusController:
 
     def __init__(self, use_case: TeiMakeCorpusUseCase) -> None:
         self.use_case = use_case
-        self._doc_id_pattern_mapping = PatternMap()
+        self._doc_id_pattern_mapping = PATTERN_MAP
 
     def process_arguments(self, arguments: List[str]) -> None:
         config_parser = argparse.ArgumentParser(

--- a/tei_make_corpus/cli/controller.py
+++ b/tei_make_corpus/cli/controller.py
@@ -126,8 +126,8 @@ class TeiMakeCorpusController:
             type=int,
             nargs="?",
             choices=self._doc_id_pattern_mapping.keys(),
-            help=f"""Add an <idno/> element to teiHeader/fileDesc/publicationStmt to each
-            TEI document in the teiCorpus containing a document identifier. The doc id
+            help=f"""Add an <idno/> element with @type='docId' attribute to teiHeader/fileDesc/publicationStmt
+            to each TEI document in the teiCorpus containing a document identifier. The doc id
             is derived from the original filename. If used without value, it defaults to 0,
             i.e. the basename of the file is added as doc id.
             Otherwise, a predefined regex is used to search the filename and extract a

--- a/tei_make_corpus/cli/controller.py
+++ b/tei_make_corpus/cli/controller.py
@@ -117,7 +117,17 @@ class TeiMakeCorpusController:
             type=int,
             nargs="?",
             choices=self._doc_id_pattern_mapping.keys(),
-            help="",
+            help=f"""Add an <idno/> element to teiHeader/fileDesc/publicationStmt to each
+            TEI document in the teiCorpus containing a document identifier. The doc id
+            is derived from the original filename. If used without value, it defaults to 0,
+            i.e. the basename of the file is added as doc id.
+            Otherwise, a predefined regex is used to search the filename and extract a
+            capturing group that should be added as identifier. If the filename can't be
+            matched, the basename is used instead and a warning is logged.
+            Possible regular expressions
+            are:
+            {self._doc_id_pattern_mapping}
+            """,
         )
         parser.set_defaults(**defaults)
         args = parser.parse_args(remaining_argv)

--- a/tei_make_corpus/cli/docid_pattern_map.py
+++ b/tei_make_corpus/cli/docid_pattern_map.py
@@ -1,0 +1,6 @@
+class PatternMap(dict):
+    def __init__(self):
+        self[0] = None  # Default: use basename
+        self[1] = r".*/\w{2,3}_(\w+)\.xml$"
+        self[2] = r".*/(\w+)\."
+        self[3] = r".*/\w{2,3}_(.+)\.xml$"

--- a/tei_make_corpus/cli/docid_pattern_map.py
+++ b/tei_make_corpus/cli/docid_pattern_map.py
@@ -1,6 +1,9 @@
-class PatternMap(dict):
-    def __init__(self):
-        self[0] = None  # Default: use basename
-        self[1] = r".*/\w{2,3}_(\w+)\.xml$"
-        self[2] = r".*/(\w+)\."
-        self[3] = r".*/\w{2,3}_(.+)\.xml$"
+"""
+Mapping for regex patterns for extraction of document id from file name.
+"""
+PATTERN_MAP = {
+    0: None,  # Default: use basename
+    1: r".*/\w{2,3}_(\w+)\.xml$",
+    2: r".*/(\w+)\.",
+    3: r".*/\w{2,3}_(.+)\.xml$",
+}

--- a/tei_make_corpus/cli/make_corpus_usecase.py
+++ b/tei_make_corpus/cli/make_corpus_usecase.py
@@ -2,8 +2,10 @@ from dataclasses import dataclass
 from typing import Optional, Protocol
 
 from tei_make_corpus.cli.corpus_config import CorpusConfig
+from tei_make_corpus.cli.docid_pattern_map import PatternMap
 from tei_make_corpus.corpus_maker import TeiCorpusMaker
 from tei_make_corpus.corpus_stream import CorpusStream
+from tei_make_corpus.doc_id_handler import DocIdToIdnoHandler
 from tei_make_corpus.file_size_estimator import FileSizeEstimatorImpl
 from tei_make_corpus.header_handler import TeiHeaderHandlerImpl
 from tei_make_corpus.partitioner import Partitioner
@@ -42,11 +44,17 @@ class TeiMakeCorpusUseCaseImpl:
         path_finder = PathFinderImpl()
         size_estimator = FileSizeEstimatorImpl()
         xmlid_handler = create_xmlid_handler(request.prefix_xmlid)
+        docid_handler = None
+        if request.docid_pattern_index is not None:
+            docid_handler = DocIdToIdnoHandler(
+                PatternMap().get(request.docid_pattern_index, None)
+            )
         partitioner = Partitioner(
             header_handler=header_handler,
             path_finder=path_finder,
             size_estimator=size_estimator,
             xmlid_handler=xmlid_handler,
+            docid_handler=docid_handler,
         )
         config = CorpusConfig(
             clean_header=request.clean_header,

--- a/tei_make_corpus/cli/make_corpus_usecase.py
+++ b/tei_make_corpus/cli/make_corpus_usecase.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Dict, Optional, Protocol
 
 from tei_make_corpus.cli.corpus_config import CorpusConfig
-from tei_make_corpus.cli.docid_pattern_map import PatternMap
+from tei_make_corpus.cli.docid_pattern_map import PATTERN_MAP
 from tei_make_corpus.construct_processing_instructions import (
     construct_processing_instructions,
 )
@@ -51,7 +51,7 @@ class TeiMakeCorpusUseCaseImpl:
         docid_handler = None
         if request.docid_pattern_index is not None:
             docid_handler = DocIdToIdnoHandler(
-                PatternMap().get(request.docid_pattern_index, None)
+                PATTERN_MAP.get(request.docid_pattern_index, None)
             )
         processing_instructions = None
         if request.processing_instructions is not None:

--- a/tei_make_corpus/cli/make_corpus_usecase.py
+++ b/tei_make_corpus/cli/make_corpus_usecase.py
@@ -20,6 +20,7 @@ class CliRequest:
     split_docs: int = -1
     split_size: int = -1
     prefix_xmlid: bool = False
+    docid_pattern_index: Optional[int] = None
 
 
 class TeiMakeCorpusUseCase(Protocol):

--- a/tei_make_corpus/doc_id_handler.py
+++ b/tei_make_corpus/doc_id_handler.py
@@ -1,0 +1,40 @@
+import logging
+import os
+from typing import Protocol
+
+from lxml import etree
+
+logger = logging.getLogger(__name__)
+
+
+class DocIdHandler(Protocol):
+    def add_doc_id(self, doc_root: etree._Element, file_path: str) -> None:
+        ...
+
+
+class DocIdToIdnoHandler:
+    def add_doc_id(self, doc_root: etree._Element, file_path: str) -> None:
+        publstmt_elem = doc_root.find(".//{*}teiHeader/{*}fileDesc/{*}publicationStmt")
+        if publstmt_elem is None:
+            logger.error(
+                "<publicationStmt> not found: Couldn't add doc id for file: %s"
+                % file_path
+            )
+            return
+        if len(publstmt_elem) == 0 or etree.QName(publstmt_elem[0]).localname == "p":
+            new_idno = etree.Element("p")
+            logger.warning("Incomplete <publicationStmt/> in file: %s" % file_path)
+        else:
+            new_idno = etree.Element("idno")
+        new_idno.text = os.path.basename(file_path)
+        insertion_index = self._determine_insertion_index(publstmt_elem)
+        publstmt_elem.insert(insertion_index, new_idno)
+
+    def _determine_insertion_index(self, parent: etree._Element) -> int:
+        insertion_index = len(parent)
+
+        if (idno_siblings := parent.findall("{*}idno")) != []:
+            insertion_index = parent.index(idno_siblings[-1]) + 1
+        elif (availability_siblings := parent.findall("{*}availability")) != []:
+            insertion_index = parent.index(availability_siblings[-1])
+        return insertion_index

--- a/tei_make_corpus/doc_id_handler.py
+++ b/tei_make_corpus/doc_id_handler.py
@@ -32,7 +32,6 @@ class DocIdToIdnoHandler:
 
     def _determine_insertion_index(self, parent: etree._Element) -> int:
         insertion_index = len(parent)
-
         if (idno_siblings := parent.findall("{*}idno")) != []:
             insertion_index = parent.index(idno_siblings[-1]) + 1
         elif (availability_siblings := parent.findall("{*}availability")) != []:

--- a/tei_make_corpus/doc_id_handler.py
+++ b/tei_make_corpus/doc_id_handler.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Protocol
+from typing import Optional, Protocol
 
 from lxml import etree
 
@@ -13,7 +13,41 @@ class DocIdHandler(Protocol):
 
 
 class DocIdToIdnoHandler:
+    """
+    Add a doc identifier as content of an <idno/> element to
+    teiHeader/fileDesc/publicationStmt. As default, it is assumed that
+    the file path is passed as input and the basename of this file path is
+    added as identifier.
+    To extract only part of the input string, a regex pattern with
+    exactly one capturing group can be used to initialze DocIdToIdnoHandler.
+    """
+
+    def __init__(self, doc_id_pattern: Optional[str] = None) -> None:
+        """
+        doc_id_pattern: Optional[str]   A string that can be compiled to
+                                        a regex pattern with one capturing
+                                        group, where the group encompasses
+                                        the part to be added as doc id.
+        """
+        self._doc_id_pattern = doc_id_pattern
+
     def add_doc_id(self, doc_root: etree._Element, file_path: str) -> None:
+        """
+        Add a <idno/> element as child of teiHeader/fileDesc/publicationStmt
+        containing the basename of file_path, or, if a doc_id_pattern was
+        set,the corresponding part of the filepath.
+        The new <idno/> element is as following sibling of the last <idno/>,
+        if present, or before any <availability/> element, if present;
+        otherwise it is added as last child of <publicationStmt/>.
+
+        doc_root: etree._Element        Root element of a element tree
+                                        representing a TEI document
+        file_path: str                  A string from which the document
+                                        id is extracted. As default, the
+                                        basename (i.e. the part of the
+                                        string after the last slash) is
+                                        used.
+        """
         publstmt_elem = doc_root.find(".//{*}teiHeader/{*}fileDesc/{*}publicationStmt")
         if publstmt_elem is None:
             logger.error(

--- a/tei_make_corpus/doc_id_handler.py
+++ b/tei_make_corpus/doc_id_handler.py
@@ -69,5 +69,5 @@ class DocIdToIdnoHandler:
         if (idno_siblings := parent.findall("{*}idno")) != []:
             insertion_index = parent.index(idno_siblings[-1]) + 1
         elif (availability_siblings := parent.findall("{*}availability")) != []:
-            insertion_index = parent.index(availability_siblings[-1])
+            insertion_index = parent.index(availability_siblings[0])
         return insertion_index

--- a/tei_make_corpus/doc_id_handler.py
+++ b/tei_make_corpus/doc_id_handler.py
@@ -87,4 +87,8 @@ class DocIdToIdnoHandler:
             doc_id = self._doc_id_pattern.search(file_path)
             if doc_id:
                 return doc_id.group(1)
+            logger.warning(
+                "Couldn't match file %s with regex '%s'"
+                % (file_path, self._doc_id_pattern.pattern)
+            )
         return os.path.basename(file_path)

--- a/tei_make_corpus/partition.py
+++ b/tei_make_corpus/partition.py
@@ -1,9 +1,10 @@
 import logging
 from dataclasses import dataclass
-from typing import BinaryIO, List, Union
+from typing import BinaryIO, List, Optional, Union
 
 from lxml import etree
 
+from tei_make_corpus.doc_id_handler import DocIdHandler
 from tei_make_corpus.header_handler import TeiHeaderHandler
 from tei_make_corpus.xmlid_handler import XmlIdHandler
 
@@ -16,6 +17,7 @@ class Partition:
     files: List[str]
     xmlid_handler: XmlIdHandler
     clean_files: bool = False
+    docid_handler: Optional[DocIdHandler] = None
 
     def write_partition(self, path: Union[str, BinaryIO]) -> None:
         with etree.xmlfile(path, encoding="UTF-8") as xf:
@@ -45,6 +47,8 @@ class Partition:
         if self.clean_files:
             self.header_handler.declutter_individual_header(iheader)
         self.xmlid_handler.process_document(root, file_path)
+        if self.docid_handler is not None:
+            self.docid_handler.add_doc_id(root, file_path)
         return root
 
     def __len__(self):

--- a/tei_make_corpus/partitioner.py
+++ b/tei_make_corpus/partitioner.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Generator, List, Optional, Tuple
 
 from tei_make_corpus.cli.corpus_config import CorpusConfig
+from tei_make_corpus.doc_id_handler import DocIdHandler
 from tei_make_corpus.file_size_estimator import FileSizeEstimator
 from tei_make_corpus.header_handler import TeiHeaderHandler
 from tei_make_corpus.partition import Partition
@@ -15,6 +16,7 @@ class Partitioner:
     path_finder: PathFinder
     size_estimator: FileSizeEstimator
     xmlid_handler: XmlIdHandler
+    docid_handler: Optional[DocIdHandler] = None
 
     def get_partitions(
         self, corpus_dir: str, header_file: str, config: Optional[CorpusConfig] = None
@@ -56,6 +58,7 @@ class Partitioner:
                 all_files[start_index:end_index],
                 self.xmlid_handler,
                 clean_files=clean_files,
+                docid_handler=self.docid_handler,
             )
 
     def _determine_chunk_indices_num_docs(

--- a/tests/test_doc_id_handler.py
+++ b/tests/test_doc_id_handler.py
@@ -1,0 +1,350 @@
+import unittest
+
+from lxml import etree
+
+from tei_make_corpus.doc_id_handler import DocIdToIdnoHandler
+
+
+class DocIdToIdnoHandlerTest(unittest.TestCase):
+    def setUp(self):
+        self.default_handler = DocIdToIdnoHandler()
+
+    def test_idno_added_to_publicationStmt(self):
+        doc = etree.XML(
+            """
+            <TEI xmlns='http://www.tei-c.org/ns/1.0'>
+            <teiHeader>
+                <fileDesc>
+                    <titleStmt/>
+                    <publicationStmt>
+                        <publisher/>
+                    </publicationStmt>
+                </fileDesc>
+            </teiHeader>
+            </TEI>
+            """
+        )
+        self.default_handler.add_doc_id(doc, "path/to/file")
+        self.assertTrue(doc.find(".//{*}publicationStmt/{*}idno") is not None)
+
+    def test_idno_element_added_before_availability(self):
+        doc = etree.XML(
+            """
+            <TEI xmlns='http://www.tei-c.org/ns/1.0'>
+            <teiHeader>
+                <fileDesc>
+                    <titleStmt/>
+                    <publicationStmt>
+                        <publisher/>
+                        <availability/>
+                    </publicationStmt>
+                </fileDesc>
+            </teiHeader>
+            </TEI>
+            """
+        )
+        self.default_handler.add_doc_id(doc, "path/to/file")
+        idno_elem = doc.find(".//{*}idno")
+        self.assertEqual(
+            idno_elem.getnext().tag, "{http://www.tei-c.org/ns/1.0}availability"
+        )
+
+    def test_idno_added_as_last_child_if_no_availability(self):
+        doc = etree.XML(
+            """
+            <TEI xmlns='http://www.tei-c.org/ns/1.0'>
+            <teiHeader>
+                <fileDesc>
+                    <titleStmt/>
+                    <publicationStmt>
+                        <publisher/>
+                        <date/>
+                    </publicationStmt>
+                </fileDesc>
+            </teiHeader>
+            </TEI>
+            """
+        )
+        self.default_handler.add_doc_id(doc, "path/to/file")
+        pubstmt_elem = doc.find(".//{*}publicationStmt")
+        self.assertEqual(pubstmt_elem[-1].tag, "idno")
+
+    def test_new_idno_added_after_existing_idno_regardless_of_siblings(self):
+        docs = [
+            etree.XML(
+                """
+                <TEI xmlns='http://www.tei-c.org/ns/1.0'>
+                <teiHeader>
+                    <fileDesc>
+                        <titleStmt/>
+                        <publicationStmt>
+                            <publisher/>
+                            <idno>old</idno>
+                            <availability/>
+                        </publicationStmt>
+                    </fileDesc>
+                </teiHeader>
+                </TEI>
+                """
+            ),
+            etree.XML(
+                """
+                <TEI xmlns='http://www.tei-c.org/ns/1.0'>
+                <teiHeader>
+                    <fileDesc>
+                        <titleStmt/>
+                        <publicationStmt>
+                            <publisher/>
+                            <availability/>
+                            <idno>old</idno>
+                        </publicationStmt>
+                    </fileDesc>
+                </teiHeader>
+                </TEI>
+                """
+            ),
+            etree.XML(
+                """
+                <TEI xmlns='http://www.tei-c.org/ns/1.0'>
+                <teiHeader>
+                    <fileDesc>
+                        <titleStmt/>
+                        <publicationStmt>
+                            <publisher/>
+                            <availability/>
+                            <idno>old</idno>
+                            <date/>
+                        </publicationStmt>
+                    </fileDesc>
+                </teiHeader>
+                </TEI>
+                """
+            ),
+            etree.XML(
+                """
+                <TEI xmlns='http://www.tei-c.org/ns/1.0'>
+                <teiHeader>
+                    <fileDesc>
+                        <titleStmt/>
+                        <publicationStmt>
+                            <publisher/>
+                            <idno>old</idno>
+                            <date/>
+                            <availability/>
+                        </publicationStmt>
+                    </fileDesc>
+                </teiHeader>
+                </TEI>
+                """
+            ),
+        ]
+        for doc in docs:
+            self.default_handler.add_doc_id(doc, "path/to/file")
+            old_idno = doc.find(".//{*}idno")
+            with self.subTest():
+                self.assertEqual(old_idno.getnext().text, "file")
+
+    def test_filename_added_as_text_of_idno_as_default(self):
+        doc = etree.XML(
+            """
+            <TEI xmlns='http://www.tei-c.org/ns/1.0'>
+            <teiHeader>
+                <fileDesc>
+                    <titleStmt/>
+                    <publicationStmt>
+                        <publisher/>
+                        <availability/>
+                    </publicationStmt>
+                </fileDesc>
+            </teiHeader>
+            </TEI>
+            """
+        )
+        self.default_handler.add_doc_id(doc, "path/to/file")
+        idno_elem = doc.find(".//{*}idno")
+        self.assertEqual(idno_elem.text, "file")
+
+    def test_content_added_to_new_p_element_if_publicationStmt_only_contains_p(self):
+        doc = etree.XML(
+            """
+            <TEI xmlns='http://www.tei-c.org/ns/1.0'>
+            <teiHeader>
+                <fileDesc>
+                    <titleStmt/>
+                    <publicationStmt>
+                        <p/>
+                        <p/>
+                    </publicationStmt>
+                </fileDesc>
+            </teiHeader>
+            </TEI>
+            """
+        )
+        self.default_handler.add_doc_id(doc, "path/to/file")
+        self.assertTrue(doc.find(".//{*}idno") is None)
+        self.assertEqual(doc.find(".//{*}publicationStmt")[-1].text, "file")
+
+    def test_idno_added_to_publicationStmt_in_fileDesc(self):
+        doc = etree.XML(
+            """
+            <TEI xmlns='http://www.tei-c.org/ns/1.0'>
+            <teiHeader>
+                <fileDesc>
+                    <titleStmt/>
+                    <publicationStmt>
+                        <publisher/>
+                        <availability/>
+                    </publicationStmt>
+                </fileDesc>
+                <sourceDesc>
+                    <biblFull>
+                        <titleStmt/>
+                        <publicationStmt>
+                            <publisher/>
+                        </publicationStmt>
+                    </biblFull>
+                </sourceDesc>
+            </teiHeader>
+            </TEI>
+            """
+        )
+        self.default_handler.add_doc_id(doc, "path/to/file")
+        self.assertTrue(
+            doc.find(".//{*}fileDesc/{*}publicationStmt/{*}idno") is not None
+        )
+
+    def test_idno_only_added_to_publicationStmt_in_fileDesc_under_teiHeader(self):
+        doc = etree.XML(
+            """
+            <TEI xmlns='http://www.tei-c.org/ns/1.0'>
+            <teiHeader>
+                <fileDesc>
+                    <titleStmt/>
+                    <publicationStmt>
+                        <publisher/>
+                        <availability/>
+                    </publicationStmt>
+                </fileDesc>
+                <sourceDesc>
+                    <biblFull>
+                        <fileDesc>
+                            <titleStmt/>
+                            <publicationStmt>
+                                <publisher/>
+                            </publicationStmt>
+                        </fileDesc>
+                    </biblFull>
+                </sourceDesc>
+            </teiHeader>
+            </TEI>
+            """
+        )
+        self.default_handler.add_doc_id(doc, "path/to/file")
+        self.assertEqual(len(doc.findall(".//{*}idno")), 1)
+
+    def test_idno_not_added_if_correct_publicationStmt_missing(self):
+        doc = etree.XML(
+            """
+            <TEI xmlns='http://www.tei-c.org/ns/1.0'>
+            <teiHeader>
+                <fileDesc>
+                    <titleStmt/>
+                </fileDesc>
+                <sourceDesc>
+                    <biblFull>
+                        <fileDesc>
+                            <titleStmt/>
+                            <publicationStmt>
+                                <publisher/>
+                            </publicationStmt>
+                        </fileDesc>
+                    </biblFull>
+                </sourceDesc>
+            </teiHeader>
+            </TEI>
+            """
+        )
+        self.default_handler.add_doc_id(doc, "path/to/file")
+        self.assertEqual(len(doc.findall(".//{*}idno")), 0)
+
+    def test_error_logged_if_correct_publicationStmt_not_present(self):
+        doc = etree.XML(
+            """
+            <TEI xmlns='http://www.tei-c.org/ns/1.0'>
+            <teiHeader>
+                <fileDesc>
+                    <titleStmt/>
+                </fileDesc>
+                <sourceDesc>
+                    <biblFull>
+                        <titleStmt/>
+                        <publicationStmt>
+                            <publisher/>
+                        </publicationStmt>
+                    </biblFull>
+                </sourceDesc>
+            </teiHeader>
+            </TEI>
+            """
+        )
+        with self.assertLogs() as logged:
+            self.default_handler.add_doc_id(doc, "path/to/file")
+        self.assertIn("ERROR", logged.output[0])
+
+    def test_filepath_logged_if_correct_publicationStmt_not_present(self):
+        doc = etree.XML(
+            """
+            <TEI xmlns='http://www.tei-c.org/ns/1.0'>
+            <teiHeader>
+                <fileDesc>
+                    <titleStmt/>
+                </fileDesc>
+                <sourceDesc>
+                    <biblFull>
+                        <titleStmt/>
+                        <publicationStmt>
+                            <publisher/>
+                        </publicationStmt>
+                    </biblFull>
+                </sourceDesc>
+            </teiHeader>
+            </TEI>
+            """
+        )
+        with self.assertLogs() as logged:
+            self.default_handler.add_doc_id(doc, "path/to/target_file")
+        self.assertIn("path/to/target_file", logged.output[0])
+
+    def test_doc_id_added_under_new_p_element_if_publicationStmt_empty(self):
+        doc = etree.XML(
+            """
+            <TEI xmlns='http://www.tei-c.org/ns/1.0'>
+            <teiHeader>
+                <fileDesc>
+                    <titleStmt/>
+                    <publicationStmt/>
+                </fileDesc>
+            </teiHeader>
+            </TEI>
+            """
+        )
+        self.default_handler.add_doc_id(doc, "path/to/file")
+        self.assertEqual(doc.find(".//{*}publicationStmt/{*}p").text, "file")
+
+    def test_warning_logged_if_publicationStmt_empty(self):
+        doc = etree.XML(
+            """
+            <TEI xmlns='http://www.tei-c.org/ns/1.0'>
+            <teiHeader>
+                <fileDesc>
+                    <titleStmt/>
+                    <publicationStmt/>
+                </fileDesc>
+            </teiHeader>
+            </TEI>
+            """
+        )
+        with self.assertLogs() as logged:
+            self.default_handler.add_doc_id(doc, "path/to/file")
+        self.assertIn("WARNING", logged.output[0])
+        self.assertIn("Incomplete <publicationStmt/>", logged.output[0])

--- a/tests/test_doc_id_handler.py
+++ b/tests/test_doc_id_handler.py
@@ -448,3 +448,25 @@ class DocIdToIdnoHandlerTest(unittest.TestCase):
         pattern_handler.add_doc_id(doc, "path/to/file.xml")
         idno_elem = doc.find(".//{*}idno")
         self.assertEqual(idno_elem.text, "file.xml")
+
+    def test_warning_logged_if_fallback_is_used(self):
+        doc = etree.XML(
+            """
+            <TEI xmlns='http://www.tei-c.org/ns/1.0'>
+            <teiHeader>
+                <fileDesc>
+                    <titleStmt/>
+                    <publicationStmt>
+                        <publisher/>
+                    </publicationStmt>
+                </fileDesc>
+            </teiHeader>
+            </TEI>
+            """
+        )
+        filepath = "path/to/file.xml"
+        pattern_handler = DocIdToIdnoHandler(r".*/(\d+)\.xml$")
+        with self.assertLogs() as logged:
+            pattern_handler.add_doc_id(doc, filepath)
+        self.assertIn("WARNING", logged.output[0])
+        self.assertIn(filepath, logged.output[0])

--- a/tests/test_doc_id_handler.py
+++ b/tests/test_doc_id_handler.py
@@ -49,6 +49,35 @@ class DocIdToIdnoHandlerTest(unittest.TestCase):
             idno_elem.getnext().tag, "{http://www.tei-c.org/ns/1.0}availability"
         )
 
+    def test_idno_element_added_before_multiple_availability(self):
+        doc = etree.XML(
+            """
+            <TEI xmlns='http://www.tei-c.org/ns/1.0'>
+            <teiHeader>
+                <fileDesc>
+                    <titleStmt/>
+                    <publicationStmt>
+                        <publisher/>
+                        <date/>
+                        <availability/>
+                        <availability/>
+                        <availability/>
+                        <availability/>
+                    </publicationStmt>
+                </fileDesc>
+            </teiHeader>
+            </TEI>
+            """
+        )
+        self.default_handler.add_doc_id(doc, "path/to/file")
+        idno_elem = doc.find(".//{*}idno")
+        self.assertEqual(
+            idno_elem.getnext().tag, "{http://www.tei-c.org/ns/1.0}availability"
+        )
+        self.assertEqual(
+            idno_elem.getprevious().tag, "{http://www.tei-c.org/ns/1.0}date"
+        )
+
     def test_idno_added_as_last_child_if_no_availability(self):
         doc = etree.XML(
             """

--- a/tests/test_doc_id_handler.py
+++ b/tests/test_doc_id_handler.py
@@ -470,3 +470,44 @@ class DocIdToIdnoHandlerTest(unittest.TestCase):
             pattern_handler.add_doc_id(doc, filepath)
         self.assertIn("WARNING", logged.output[0])
         self.assertIn(filepath, logged.output[0])
+
+    def test_type_attribute_added(self):
+        doc = etree.XML(
+            """
+            <TEI xmlns='http://www.tei-c.org/ns/1.0'>
+            <teiHeader>
+                <fileDesc>
+                    <titleStmt/>
+                    <publicationStmt>
+                        <publisher/>
+                        <availability/>
+                    </publicationStmt>
+                </fileDesc>
+            </teiHeader>
+            </TEI>
+            """
+        )
+        self.default_handler.add_doc_id(doc, "path/to/file")
+        self.assertEqual(
+            doc.find(".//{*}fileDesc/{*}publicationStmt/{*}idno").attrib,
+            {"type": "docId"},
+        )
+
+    def test_no_type_attribute_added_if_new_element_is_p(self):
+        doc = etree.XML(
+            """
+            <TEI xmlns='http://www.tei-c.org/ns/1.0'>
+            <teiHeader>
+                <fileDesc>
+                    <titleStmt/>
+                    <publicationStmt>
+                        <p n='1'/>
+                        <p n='2'/>
+                    </publicationStmt>
+                </fileDesc>
+            </teiHeader>
+            </TEI>
+            """
+        )
+        self.default_handler.add_doc_id(doc, "path/to/file")
+        self.assertEqual(doc.find(".//{*}publicationStmt")[-1].attrib, {})

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -323,6 +323,60 @@ class IntegrationTest(unittest.TestCase):
         ]
         self.assertEqual(result, expected)
 
+    def test_basename_added_as_doc_id(self):
+        request = CliRequest(
+            header_file=os.path.join(self.test_dir, "xmlid", "header.xml"),
+            corpus_dir=os.path.join(self.test_dir, "xmlid"),
+            docid_pattern_index=0,
+        )
+        with contextlib.redirect_stdout(
+            io.TextIOWrapper(io.BytesIO(), sys.stdout.encoding)
+        ) as pseudo:
+            self.use_case.process(request)
+        pseudo.seek(0)
+        doc = etree.parse(pseudo)
+        doc_ids = [
+            elem.text
+            for elem in doc.findall(".//{*}fileDesc/{*}publicationStmt/{*}idno")
+        ]
+        self.assertEqual(doc_ids, ["file1.xml", "file2.xml"])
+
+    def test_regex_extracted_doc_id_added(self):
+        request = CliRequest(
+            header_file=os.path.join(self.test_dir, "xmlid", "header.xml"),
+            corpus_dir=os.path.join(self.test_dir, "xmlid"),
+            docid_pattern_index=2,
+        )
+        with contextlib.redirect_stdout(
+            io.TextIOWrapper(io.BytesIO(), sys.stdout.encoding)
+        ) as pseudo:
+            self.use_case.process(request)
+        pseudo.seek(0)
+        doc = etree.parse(pseudo)
+        doc_ids = [
+            elem.text
+            for elem in doc.findall(".//{*}fileDesc/{*}publicationStmt/{*}idno")
+        ]
+        self.assertEqual(doc_ids, ["file1", "file2"])
+
+    def test_doc_id_not_added_if_option_not_used(self):
+        request = CliRequest(
+            header_file=os.path.join(self.test_dir, "xmlid", "header.xml"),
+            corpus_dir=os.path.join(self.test_dir, "xmlid"),
+            docid_pattern_index=None,
+        )
+        with contextlib.redirect_stdout(
+            io.TextIOWrapper(io.BytesIO(), sys.stdout.encoding)
+        ) as pseudo:
+            self.use_case.process(request)
+        pseudo.seek(0)
+        doc = etree.parse(pseudo)
+        doc_ids = [
+            elem.text
+            for elem in doc.findall(".//{*}fileDesc/{*}publicationStmt/{*}idno")
+        ]
+        self.assertEqual(doc_ids, [])
+
     def _remove_output_files(self, dir=None, pattern=None):
         dir = dir or self.test_dir
         other_files = [file for file in os.listdir(dir) if re.match(pattern, file)]

--- a/tests/test_partitioner.py
+++ b/tests/test_partitioner.py
@@ -3,6 +3,7 @@ import random
 import unittest
 
 from tei_make_corpus.cli.corpus_config import CorpusConfig
+from tei_make_corpus.doc_id_handler import DocIdToIdnoHandler
 from tei_make_corpus.partitioner import Partitioner
 from tei_make_corpus.xmlid_handler import XmlIdRemover
 from tests.utils import MockHeaderHandler
@@ -239,3 +240,15 @@ class PartitionerTest(unittest.TestCase):
         config = CorpusConfig(clean_header=False, split_size=1000)
         partitions = self.partitioner.get_partitions("empty", self.header_file, config)
         self.assertEqual(list(partitions), [])
+
+    def test_partition_instantiated_with_doc_id_handler(self):
+        partitioner = Partitioner(
+            header_handler=self.mock_header_handler,
+            path_finder=self.mock_path_finder,
+            size_estimator=self.size_estimator,
+            xmlid_handler=self.id_handler,
+            docid_handler=DocIdToIdnoHandler(),
+        )
+        self.mock_path_finder.files["test"] = ["test/subdir/file.xml"]
+        result = next(partitioner.get_partitions("test", self.header_file))
+        self.assertTrue(result.docid_handler, DocIdToIdnoHandler)

--- a/tests/testdata/config/docid.cfg
+++ b/tests/testdata/config/docid.cfg
@@ -1,0 +1,1 @@
+add_docid = 0

--- a/tests/testdata/config/invalid-docid.cfg
+++ b/tests/testdata/config/invalid-docid.cfg
@@ -1,0 +1,1 @@
+add_docid = 5

--- a/tests/testdata/config/invalid-docid2.cfg
+++ b/tests/testdata/config/invalid-docid2.cfg
@@ -1,0 +1,1 @@
+add_docid ="a"


### PR DESCRIPTION
Add `--add-docid` option to CLI to add an `<idno/>` element to `teiHeader/fileDesc/publicationStmt` containing a doc id. As default, the basename of each file is used. 